### PR TITLE
Resolve error when deleting bookmarks

### DIFF
--- a/app/controllers/bookmarklets_controller.rb
+++ b/app/controllers/bookmarklets_controller.rb
@@ -20,7 +20,6 @@ class BookmarkletsController < ApplicationController
     if @feed.is_bookmarking_feed?
       @feed.feed_items.delete(@feed_item)
       flash[:notice] = %Q|Removed "#{@feed_item.title}" from that bookmark collection|
-      @feed_item.update_filtered_tags
     else
       flash[:notice] = %Q|Could not remove "#{@feed_item.title}" from that bookmark collection|
     end


### PR DESCRIPTION
This method was removed in dcddc1a40dcee942303110c531c4227cad3b7608 but the method call was not removed from the controller, thus leading TagTeam to crash in production. This removes the method call and its removal does not appear to impact any functionality.