### PR TITLE
#39 Fix - count(tags, bigint) does not exist in HAML

### DIFF
--- a/app/views/tags/_statistics.html.haml
+++ b/app/views/tags/_statistics.html.haml
@@ -1,8 +1,9 @@
+- tags_count = tags.each.count
 %h2 Statistics
 %p
-  There #{'is'.pluralize(tags.count)} currently
-  %span.badge= tags.count
-  = 'tag'.pluralize(tags.count)
+  There #{'is'.pluralize(tags_count)} currently
+  %span.badge= tags_count
+  = 'tag'.pluralize()
   in use in this hub.
 
 - if prefixed_tags.any?


### PR DESCRIPTION
#39 error is due to `tags.count` in HAML being translated into an undefined PG query in the `app/views/tags/_statistics.html.haml` file. A possible fix could be adding an `each.count`. 