### PR TITLE
Fix flash message for a non-existent tags page

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -127,7 +127,7 @@ class TagsController < ApplicationController
              ActsAsTaggableOn::Tag.find_by(id: params[:id])
            end
     unless @tag
-      flash.now[:error] = "We're sorry, but '#{params[:name]}' is not a tag for '#{@hub.title}'"
+      flash[:error] = "We're sorry, but '#{params[:id]}' is not a tag for '#{@hub.title}'"
 
       redirect_to hub_path(@hub)
     end


### PR DESCRIPTION
As mentioned in #50, the application currently redirects the user to "all items" screen for the hub, if a tags page does not exist. The solution is to use `flash` instead of `flash.now`, as the latter is only used for rendering.